### PR TITLE
.github/workflows/release.yml:update build action to v1.2

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - run: echo "MOD_VERSION=${MOD_VERSION:1}" >> $GITHUB_ENV
-    - uses:  0ad-matters/gh-action-build-pyromod@v1
+    - uses:  0ad-matters/gh-action-build-pyromod@v1.2
       with:
         name: ${{ env.MOD_NAME }}
         version: ${{ env.MOD_VERSION }}


### PR DESCRIPTION
So... next time you release, the unneeded '.github' directory will be auto-removed from the pyromod file.

* remove .github* from the built pyromod file
* release v1.1
* fix docs related to the release action
* release v1.2

https://github.com/0ad-matters/gh-action-build-pyromod/blob/trunk/ChangeLog