### PR TITLE
.github/workflows/release.yml:point build action to v1 tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - run: echo "MOD_VERSION=${MOD_VERSION:1}" >> $GITHUB_ENV
-    - uses:  0ad-matters/gh-action-build-pyromod@v1.2
+    - uses:  0ad-matters/gh-action-build-pyromod@v1
       with:
         name: ${{ env.MOD_NAME }}
         version: ${{ env.MOD_VERSION }}


### PR DESCRIPTION
1.x.x releases will point to v1 from now on

https://michaelheap.com/semantic-versioning-for-github-actions/

https://github.com/actions/toolkit/blob/master/docs/action-versioning.md#versioning