### PR TITLE
Fix a27 migration errors

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,9 +12,9 @@ jobs:
       MOD_NAME: deathmatch_gamemode
       MOD_VERSION: ${{ github.ref_name }}
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - run: echo "MOD_VERSION=${MOD_VERSION:1}" >> $GITHUB_ENV
-    - uses:  0ad-matters/gh-action-build-pyromod@v1
+    - uses:  0ad-matters/gh-action-build-pyromod@v2
       with:
         name: ${{ env.MOD_NAME }}
         version: ${{ env.MOD_VERSION }}

--- a/Readme.MD
+++ b/Readme.MD
@@ -4,6 +4,6 @@ This modification for [0 A.D: Empires Ascendant](https://play0ad.com)
 adds a new game mode to the game setup. When enabled, all upgrades are
 researched at the start of the game.
 
-When hosting a game, the option is located under `Game Setup->Death
-Match` (unrelated to `Starting Resources->DeathMatch`).
+When setting up a game, the option is located under `Game Type->Death Match`
+(unrelated to `Starting Resources->DeathMatch`).
 

--- a/maps/scripts/DeathMatch.js
+++ b/maps/scripts/DeathMatch.js
@@ -6,6 +6,11 @@
 function hasReq(civ, tech) {
     const template = TechnologyTemplates.Get(tech);
 
+    // It's very easy to win against the AI when the game
+    // starts with City Phase. Don't activate it.
+    if (template.genericName === "City Phase")
+        return false;
+
     // Some civs do not get the same upgrades. Requirements are specified
     // in the templates
     if (!template.requirements?.all) {

--- a/maps/scripts/DeathMatch.js
+++ b/maps/scripts/DeathMatch.js
@@ -6,11 +6,6 @@
 function hasReq(civ, tech) {
     const template = TechnologyTemplates.Get(tech);
 
-    // It's very easy to win against the AI when the game
-    // starts with City Phase. Don't activate it.
-    if (template.genericName === "City Phase")
-        return false;
-
     // Some civs do not get the same upgrades. Requirements are specified
     // in the templates
     if (!template.requirements?.all) {

--- a/maps/scripts/DeathMatch.js
+++ b/maps/scripts/DeathMatch.js
@@ -8,6 +8,10 @@ function hasReq(civ, tech) {
 
     // Some civs do not get the same upgrades. Requirements are specified
     // in the templates
+    if (!template.requirements?.all) {
+        return true;
+    }
+
     let tReq = template.requirements.all;
     let tAny = [];
 

--- a/mod.json
+++ b/mod.json
@@ -4,5 +4,5 @@
 	"version": "0.27.0",
 	"url": "",
 	"description": "Adds a mode that researches all technologies for all players.",
-	"dependencies": ["0ad=0.27.0"]
+	"dependencies": ["0ad>=0.0.26","0ad<=0.27.0"]
 }


### PR DESCRIPTION
This auto-researches most everything. But for some reason, some upgrades from the CC aren't auto-researched. Like Archery Tradition (Kushites) and Hellenestic Metropolis (Seleucids). All Carthage upgrades from CC are auto-researched. Those are the three I checked so far. All Blacksmith, storehouse, and farmstead upgrades are auto-researched. Barracks upgrades.

With Seleucids, two stable upgrades aren't done, but I think those are the ones where there is a choice, and maybe that's how we had it before.